### PR TITLE
chore: GKE 배포 설정 추가 (inspection-service)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Build & Deploy inspection-service
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/inspection-service
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build Docker image
+        run: docker build -t $IMAGE:${{ github.sha }} -t $IMAGE:latest .
+
+      - name: Push image
+        run: docker push --all-tags $IMAGE
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Deployment (with image tag substitution)
+        run: sed "s|PLACEHOLDER|${{ github.sha }}|g" k8s/deployment.yaml | kubectl apply -f -
+
+      - name: Apply Service
+        run: kubectl apply -f k8s/service.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/inspection-service --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+FROM gradle:8.10-jdk21-alpine AS builder
+WORKDIR /workspace
+
+COPY settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN gradle bootJar --no-daemon \
+ && cp build/libs/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -g 1000 -S spring && adduser -u 1000 -S spring -G spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring:spring
+
+EXPOSE 8201
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inspection-service
+  labels:
+    app: inspection-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inspection-service
+  template:
+    metadata:
+      labels:
+        app: inspection-service
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: inspection-service
+          image: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/inspection-service:PLACEHOLDER
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8201
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_PASSWORD
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          # startupProbe — /actuator/health/liveness (application 자체만).
+          # /actuator/health (전체 합산) 는 외부 의존성 (Kafka 등) DOWN 시 503 → kill.
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8201
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8201
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8201
+            periodSeconds: 5

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: inspection-service
+  labels:
+    app: inspection-service
+spec:
+  type: ClusterIP
+  selector:
+    app: inspection-service
+  ports:
+    - port: 80
+      targetPort: 8201
+      protocol: TCP

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -1,0 +1,45 @@
+# K8s 환경 전용 override (SPRING_PROFILES_ACTIVE=k8s 일 때만 로드).
+
+server:
+  port: 8201
+
+spring:
+  config:
+    import: "optional:configserver:http://config-server"
+  cloud:
+    config:
+      uri: http://config-server
+      label: develop
+      fail-fast: false
+  datasource:
+    url: jdbc:postgresql://postgres:5432/trusta_market
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        default_schema: p_inspection
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+  # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker.
+  # KafkaListener 가 Acknowledgment 안 받음 → default ack-mode 사용 (manual 박지 말 것).
+  kafka:
+    bootstrap-servers: kafka.kafka:9092
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,13 @@ spring:
     config:
       label: develop
       fail-fast: false
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus


### PR DESCRIPTION
## 🌱 설명

inspection-service 의 GKE 배포 설정 추가.

## 📌 관련 이슈

-

## ✅ 주요 변경 사항

- `application-k8s.yml` (port 8201, schema p_inspection, Kafka kafka.kafka:9092, config-server / Eureka)
- `Dockerfile`
- `k8s/{deployment,service}.yaml`
- `.github/workflows/deploy.yml` — develop push 트리거

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

common 모듈 미사용이라 다른 서비스 대비 단순화:
- Spring Security 의존성 없음 → /actuator/health/** probe 자유 통과
- Dockerfile / workflow 에 GPR (`secrets.GPR_USER/GPR_TOKEN`) 인자 불필요
- Kafka listener 가 `Acknowledgment` 안 받음 → ack-mode 박지 않음 (default 사용)

머지 전 DB 스키마 생성 필요:
`kubectl exec deployment/postgres -- psql -U trusta_admin -d trusta_market -c "CREATE SCHEMA IF NOT EXISTS p_inspection"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 도커 멀티스테이지 빌드로 애플리케이션 컨테이너화 완료
  * Kubernetes 배포 및 서비스 매니페스트 추가
  * 자동화된 배포 파이프라인 구축 (GCP 기반 인증)
  * 헬스 체크, 리소스 제한, 보안 정책 설정 적용
  * Kafka 및 데이터베이스 통합 설정 구성

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/inspection-service/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->