### PR TITLE
fix(liquibase): p_inspection schema 분리 (default-schema + liquibase-schema)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -15,6 +15,12 @@ spring:
     url: jdbc:postgresql://postgres:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  # inspection / delivery 가 같은 V001__init.sql changeset (id 1-4, author seungwon) 을 쓰는데
+  # 두 service 가 public.databasechangelog 공유하면 file 내용 다를 때 checksum mismatch.
+  # → p_inspection schema 의 databasechangelog 으로 분리. row 는 별도 SQL 로 NULL md5 박아둠 (Liquibase 가 부팅 시 재계산).
+  liquibase:
+    default-schema: p_inspection
+    liquibase-schema: p_inspection
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 🌱 설명

`hibernate.default_schema: p_inspection` 이미 있는데 `spring.liquibase.default-schema` 가 빠져있어서 새 deploy 시 Liquibase 가 여전히 `public.databasechangelog` 봐서 checksum mismatch → 부팅 실패 예상. delivery PR #31 와 같은 패턴.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- `application-k8s.yml` 의 spring 블록에 `liquibase.default-schema: p_inspection` / `liquibase-schema: p_inspection` 추가

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

DB 작업 (이미 적용됨):
- p_inspection.databasechangelog / databasechangeloglock 생성
- public.databasechangelog 의 seungwon 4 row 를 p_inspection.databasechangelog 로 복사 (md5 NULL)
- 부팅 시 Liquibase 가 NULL md5 발견 → file 의 md5 로 재계산 + 박음 → changeset skip → 정상 부팅

delivery PR #31 머지 + 검증 후 inspection PR 머지 권장 (한 번에 둘 다 머지하면 fail 추적 어려움).