### PR TITLE
fix(yaml): inspection duplicate liquibase 제거 (PR #52 의 schema 분리 살림)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -29,11 +29,6 @@ spring:
         default_schema: p_inspection
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
-  liquibase:
-    enabled: true
-    change-log: classpath:db/changelog/db.changelog-master.yml
-    default-schema: p_inspection
-    liquibase-schema: p_inspection
   # Kafka — GKE namespace 'kafka' 의 StatefulSet 3 broker.
   # KafkaListener 가 Acknowledgment 안 받음 → default ack-mode 사용 (manual 박지 말 것).
   kafka:


### PR DESCRIPTION
## 🌱 설명

delivery PR #33 와 같은 패턴. duplicate `liquibase:` 키로 YAML parse fail. PR #52 의 첫 번째 블록 유지, 팀원 commit 의 두 번째 블록 제거.

## ✅ 주요 변경 사항

- 두 번째 `liquibase:` 블록 제거
- 첫 번째 `liquibase:` 블록 (default-schema + liquibase-schema) 유지

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

DB 상태: p_inspection.databasechangelog 3 row 정상.