### PR TITLE
[fix] Kafka 컨슈머 오프셋 미커밋으로 토픽 전체 재처리 - Inbox 멱등성 적용

### DIFF
--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumer.java
@@ -7,6 +7,7 @@ import com.trustamarket.inspectionservice.inspection.application.port.in.MarkArr
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,16 +19,20 @@ public class CarrierDeliveryCompletedConsumer {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "carrier.delivery_completed", groupId = "inspection-service")
-    public void consume(String payload) {
+    public void consume(String payload, Acknowledgment ack) {
         CarrierDeliveryCompletedEvent event;
         try {
             event = objectMapper.readValue(payload, CarrierDeliveryCompletedEvent.class);
         } catch (JsonProcessingException e) {
-            log.error("carrier.delivery_completed 이벤트 역직렬화 실패: payload={}", payload, e);
-            throw new RuntimeException(e);
+            // 잘못된 payload는 재시도해도 실패 → ack로 건너뛰어 무한 재소비(poison-pill) 차단
+            log.error("carrier.delivery_completed 이벤트 역직렬화 실패 — skip: payload={}", payload, e);
+            ack.acknowledge();
+            return;
         }
 
         markArrivedUseCase.markArrived(new MarkArrivedCommand(event.productId()));
         log.info("상품 도착 확인 완료: productId={}", event.productId());
+        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        ack.acknowledge();
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumer.java
@@ -7,6 +7,7 @@ import com.trustamarket.inspectionservice.inspection.application.port.in.Complet
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,16 +19,20 @@ public class CarrierReturnCompletedConsumer {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "carrier.return_completed", groupId = "inspection-service")
-    public void consume(String payload) {
+    public void consume(String payload, Acknowledgment ack) {
         CarrierReturnCompletedEvent event;
         try {
             event = objectMapper.readValue(payload, CarrierReturnCompletedEvent.class);
         } catch (JsonProcessingException e) {
-            log.error("carrier.return_completed 이벤트 역직렬화 실패: payload={}", payload, e);
-            throw new RuntimeException(e);
+            // 잘못된 payload는 재시도해도 실패 → ack로 건너뛰어 무한 재소비(poison-pill) 차단
+            log.error("carrier.return_completed 이벤트 역직렬화 실패 — skip: payload={}", payload, e);
+            ack.acknowledge();
+            return;
         }
 
         completeReturnUseCase.completeReturn(new CompleteReturnCommand(event.productId()));
         log.info("반송 완료 처리: productId={}", event.productId());
+        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        ack.acknowledge();
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumer.java
@@ -7,6 +7,7 @@ import com.trustamarket.inspectionservice.inspection.application.port.in.AcceptP
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -20,16 +21,20 @@ public class InspectionPriceAcceptedConsumer {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "inspection.price.accepted", groupId = "inspection-service")
-    public void consume(String payload) {
+    public void consume(String payload, Acknowledgment ack) {
         InspectionPriceAcceptedEvent event;
         try {
             event = objectMapper.readValue(payload, InspectionPriceAcceptedEvent.class);
         } catch (JsonProcessingException e) {
-            log.error("inspection.price.accepted 역직렬화 실패: payload={}", payload, e);
-            throw new RuntimeException(e);
+            // 잘못된 payload는 재시도해도 실패 → ack로 건너뛰어 무한 재소비(poison-pill) 차단
+            log.error("inspection.price.accepted 역직렬화 실패 — skip: payload={}", payload, e);
+            ack.acknowledge();
+            return;
         }
         acceptPriceUseCase.accept(new AcceptPriceCommand(event.productId()));
         log.info("가격 수락 처리 완료: productId={}", event.productId());
+        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        ack.acknowledge();
     }
 
     record InspectionPriceAcceptedEvent(UUID productId, UUID sellerId, Long finalPrice) {}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumer.java
@@ -7,6 +7,7 @@ import com.trustamarket.inspectionservice.inspection.application.port.in.RejectP
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -20,16 +21,20 @@ public class InspectionPriceRejectedConsumer {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "inspection.price.rejected", groupId = "inspection-service")
-    public void consume(String payload) {
+    public void consume(String payload, Acknowledgment ack) {
         InspectionPriceRejectedEvent event;
         try {
             event = objectMapper.readValue(payload, InspectionPriceRejectedEvent.class);
         } catch (JsonProcessingException e) {
-            log.error("inspection.price.rejected 역직렬화 실패: payload={}", payload, e);
-            throw new RuntimeException(e);
+            // 잘못된 payload는 재시도해도 실패 → ack로 건너뛰어 무한 재소비(poison-pill) 차단
+            log.error("inspection.price.rejected 역직렬화 실패 — skip: payload={}", payload, e);
+            ack.acknowledge();
+            return;
         }
         rejectPriceUseCase.reject(new RejectPriceCommand(event.productId()));
         log.info("가격 거절 처리 완료 (반송 예정): productId={}", event.productId());
+        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        ack.acknowledge();
     }
 
     record InspectionPriceRejectedEvent(UUID productId, UUID sellerId, String reason) {}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionRequestedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionRequestedConsumer.java
@@ -7,6 +7,7 @@ import com.trustamarket.inspectionservice.inspection.application.port.in.Request
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,13 +19,15 @@ public class InspectionRequestedConsumer {
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = "inspection.requested", groupId = "inspection-service")
-    public void consume(String payload) {
+    public void consume(String payload, Acknowledgment ack) {
         InspectionRequestedEvent event;
         try {
             event = objectMapper.readValue(payload, InspectionRequestedEvent.class);
         } catch (JsonProcessingException e) {
-            log.error("inspection.requested 이벤트 역직렬화 실패: payload={}", payload, e);
-            throw new RuntimeException(e);
+            // 잘못된 payload는 재시도해도 실패 → ack로 건너뛰어 무한 재소비(poison-pill) 차단
+            log.error("inspection.requested 이벤트 역직렬화 실패 — skip: payload={}", payload, e);
+            ack.acknowledge();
+            return;
         }
 
         requestInspectionUseCase.request(new RequestInspectionCommand(
@@ -32,5 +35,7 @@ public class InspectionRequestedConsumer {
                 event.originalPriceAmount(), event.currency()
         ));
         log.info("검수 요청 생성 완료: productId={}, centerId={}", event.productId(), event.centerId());
+        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        ack.acknowledge();
     }
 }


### PR DESCRIPTION
## 🌱 설명

Kafka 컨슈머 오프셋 미커밋으로 토픽 전체 재처리 문제를 해결했습니다.

## 📌 관련 이슈

close #61 

## ✅ 주요 변경 사항

- consumer 내 ack 처리 로직 추가

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 메시지 처리의 신뢰성 개선: 형식이 잘못된 메시지가 발생할 경우, 오류를 기록하고 처리를 건너뛰어 메시지 재시도 무한 루프 상황을 방지합니다.
  * 메시지 소비 처리가 더욱 안정적으로 작동하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->