### PR TITLE
[fix] at-least-once 재배달로 인한 검수 중복 생성 - Inbox 멱등성 도입

### DIFF
--- a/src/main/java/com/trustamarket/inspectionservice/center/adapter/in/web/dto/request/UpdateCenterRequest.java
+++ b/src/main/java/com/trustamarket/inspectionservice/center/adapter/in/web/dto/request/UpdateCenterRequest.java
@@ -1,9 +1,7 @@
 package com.trustamarket.inspectionservice.center.adapter.in.web.dto.request;
 
 import com.trustamarket.inspectionservice.center.application.dto.command.UpdateCenterCommand;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumer.java
@@ -4,23 +4,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.AcceptPriceCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.AcceptPriceUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class InspectionPriceAcceptedConsumer {
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+
     private final AcceptPriceUseCase acceptPriceUseCase;
+    private final InboxMessageHandler inboxMessageHandler;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "inspection.price.accepted", groupId = "inspection-service")
+    @KafkaListener(topics = "inspection.price.accepted", groupId = CONSUMER_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         InspectionPriceAcceptedEvent event;
         try {
@@ -31,11 +34,16 @@ public class InspectionPriceAcceptedConsumer {
             ack.acknowledge();
             return;
         }
-        acceptPriceUseCase.accept(new AcceptPriceCommand(event.productId()));
-        log.info("가격 수락 처리 완료: productId={}", event.productId());
-        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+
+        boolean processed = inboxMessageHandler.process(
+                event.eventId(), CONSUMER_GROUP, InboxPurpose.INSPECTION_PRICE_ACCEPTED,
+                () -> acceptPriceUseCase.accept(new AcceptPriceCommand(event.productId())));
+
+        if (processed) {
+            log.info("가격 수락 처리 완료: eventId={}, productId={}", event.eventId(), event.productId());
+        } else {
+            log.info("inspection.price.accepted 중복 메시지 — skip: eventId={}, productId={}", event.eventId(), event.productId());
+        }
         ack.acknowledge();
     }
-
-    record InspectionPriceAcceptedEvent(UUID productId, UUID sellerId, Long finalPrice) {}
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedEvent.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedEvent.java
@@ -2,12 +2,10 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 
 import java.util.UUID;
 
-record InspectionRequestedEvent(
+public record InspectionPriceAcceptedEvent(
         UUID eventId,
         UUID productId,
         UUID sellerId,
-        UUID centerId,
-        long originalPriceAmount,
-        String currency
+        Long finalPrice
 ) {
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumer.java
@@ -4,23 +4,26 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.RejectPriceCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.RejectPriceUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class InspectionPriceRejectedConsumer {
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+
     private final RejectPriceUseCase rejectPriceUseCase;
+    private final InboxMessageHandler inboxMessageHandler;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "inspection.price.rejected", groupId = "inspection-service")
+    @KafkaListener(topics = "inspection.price.rejected", groupId = CONSUMER_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         InspectionPriceRejectedEvent event;
         try {
@@ -31,11 +34,16 @@ public class InspectionPriceRejectedConsumer {
             ack.acknowledge();
             return;
         }
-        rejectPriceUseCase.reject(new RejectPriceCommand(event.productId()));
-        log.info("가격 거절 처리 완료 (반송 예정): productId={}", event.productId());
-        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+
+        boolean processed = inboxMessageHandler.process(
+                event.eventId(), CONSUMER_GROUP, InboxPurpose.INSPECTION_PRICE_REJECTED,
+                () -> rejectPriceUseCase.reject(new RejectPriceCommand(event.productId())));
+
+        if (processed) {
+            log.info("가격 거절 처리 완료 (반송 예정): eventId={}, productId={}", event.eventId(), event.productId());
+        } else {
+            log.info("inspection.price.rejected 중복 메시지 — skip: eventId={}, productId={}", event.eventId(), event.productId());
+        }
         ack.acknowledge();
     }
-
-    record InspectionPriceRejectedEvent(UUID productId, UUID sellerId, String reason) {}
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedEvent.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedEvent.java
@@ -2,12 +2,10 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 
 import java.util.UUID;
 
-record InspectionRequestedEvent(
+public record InspectionPriceRejectedEvent(
         UUID eventId,
         UUID productId,
         UUID sellerId,
-        UUID centerId,
-        long originalPriceAmount,
-        String currency
+        String reason
 ) {
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionRequestedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionRequestedConsumer.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.RequestInspectionCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.RequestInspectionUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,10 +17,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class InspectionRequestedConsumer {
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+
     private final RequestInspectionUseCase requestInspectionUseCase;
+    private final InboxMessageHandler inboxMessageHandler;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "inspection.requested", groupId = "inspection-service")
+    // dedup+도메인은 InboxMessageHandler가 한 트랜잭션으로 처리. 반환 시점엔 커밋 완료 → 동기 ack 안전(유실 0).
+    @KafkaListener(topics = "inspection.requested", groupId = CONSUMER_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         InspectionRequestedEvent event;
         try {
@@ -30,12 +36,17 @@ public class InspectionRequestedConsumer {
             return;
         }
 
-        requestInspectionUseCase.request(new RequestInspectionCommand(
-                event.productId(), event.sellerId(), event.centerId(),
-                event.originalPriceAmount(), event.currency()
-        ));
-        log.info("검수 요청 생성 완료: productId={}, centerId={}", event.productId(), event.centerId());
-        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        boolean processed = inboxMessageHandler.process(
+                event.eventId(), CONSUMER_GROUP, InboxPurpose.INSPECTION_REQUESTED,
+                () -> requestInspectionUseCase.request(new RequestInspectionCommand(
+                        event.productId(), event.sellerId(), event.centerId(),
+                        event.originalPriceAmount(), event.currency())));
+
+        if (processed) {
+            log.info("검수 요청 생성 완료: eventId={}, productId={}, centerId={}", event.eventId(), event.productId(), event.centerId());
+        } else {
+            log.info("inspection.requested 중복 메시지 — skip: eventId={}, productId={}", event.eventId(), event.productId());
+        }
         ack.acknowledge();
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaAdapter.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaAdapter.java
@@ -1,0 +1,27 @@
+package com.trustamarket.inspectionservice.inspection.adapter.out.persistence.inbox;
+
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+// InboxRepository의 JPA 구현. 트랜잭션 경계는 호출자(consumer 리스너)가 잡으며,
+// 여기서 별도 @Transactional을 두지 않아 도메인 처리와 같은 트랜잭션에 참여한다.
+@Repository
+@RequiredArgsConstructor
+public class InboxJpaAdapter implements InboxRepository {
+
+    private final InboxJpaRepository inboxJpaRepository;
+
+    @Override
+    public boolean isAlreadyProcessed(UUID eventId, String consumerGroup) {
+        return inboxJpaRepository.existsByEventIdAndConsumerGroup(eventId, consumerGroup);
+    }
+
+    @Override
+    public void record(UUID eventId, String consumerGroup, InboxPurpose purpose) {
+        inboxJpaRepository.save(InboxJpaEntity.forKafkaEvent(eventId, consumerGroup, purpose));
+    }
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaEntity.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaEntity.java
@@ -1,0 +1,59 @@
+package com.trustamarket.inspectionservice.inspection.adapter.out.persistence.inbox;
+
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+// p_inspection_inboxes — Kafka 메시지 멱등성 기록.
+// (event_id, consumer_group) UNIQUE — at-least-once 재배달 시 동일 메시지 중복 처리 차단.
+@Entity
+@Table(name = "p_inspection_inboxes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InboxJpaEntity {
+
+    @Id
+    @Column(name = "id", columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "event_id", columnDefinition = "uuid", nullable = false, updatable = false)
+    private UUID eventId;
+
+    @Column(name = "consumer_group", length = 50, nullable = false, updatable = false)
+    private String consumerGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose", length = 30, nullable = false, updatable = false)
+    private InboxPurpose purpose;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    private InboxJpaEntity(UUID id, UUID eventId, String consumerGroup, InboxPurpose purpose, Instant createdAt) {
+        this.id = id;
+        this.eventId = eventId;
+        this.consumerGroup = consumerGroup;
+        this.purpose = purpose;
+        this.createdAt = createdAt;
+    }
+
+    public static InboxJpaEntity forKafkaEvent(UUID eventId, String consumerGroup, InboxPurpose purpose) {
+        Objects.requireNonNull(eventId, "eventId must not be null");
+        Objects.requireNonNull(purpose, "purpose must not be null");
+        if (consumerGroup == null || consumerGroup.isBlank()) {
+            throw new IllegalArgumentException("consumerGroup must not be blank");
+        }
+        return new InboxJpaEntity(UUID.randomUUID(), eventId, consumerGroup, purpose, Instant.now());
+    }
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaRepository.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaRepository.java
@@ -1,0 +1,10 @@
+package com.trustamarket.inspectionservice.inspection.adapter.out.persistence.inbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InboxJpaRepository extends JpaRepository<InboxJpaEntity, UUID> {
+
+    boolean existsByEventIdAndConsumerGroup(UUID eventId, String consumerGroup);
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxPurpose.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxPurpose.java
@@ -1,0 +1,8 @@
+package com.trustamarket.inspectionservice.inspection.application.port.out;
+
+// inbox row가 어떤 Kafka 소비 흐름의 멱등성 기록인지 — 관측/디버깅용. dedup 키는 (event_id, consumer_group).
+public enum InboxPurpose {
+    INSPECTION_REQUESTED,
+    INSPECTION_PRICE_ACCEPTED,
+    INSPECTION_PRICE_REJECTED
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxRepository.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxRepository.java
@@ -1,0 +1,16 @@
+package com.trustamarket.inspectionservice.inspection.application.port.out;
+
+import java.util.UUID;
+
+// Kafka 소비 멱등성 port — application 레이어가 persistence(Inbox JPA)에 직접 의존하지 않게 추상화.
+//
+// 동일 트랜잭션 dedup: isAlreadyProcessed(SELECT) → 도메인 처리 → record(INSERT)를 한 트랜잭션으로 묶는다.
+// 같은 eventId는 같은 파티션(productId key)→같은 스레드로 순차 처리되므로 exists-check에 race가 없다.
+public interface InboxRepository {
+
+    // (eventId, consumerGroup)가 이미 기록돼 있으면 true — 중복 메시지.
+    boolean isAlreadyProcessed(UUID eventId, String consumerGroup);
+
+    // 처리 완료를 기록. 도메인 작업과 같은 트랜잭션에서 커밋돼야 유실/중복이 모두 0.
+    void record(UUID eventId, String consumerGroup, InboxPurpose purpose);
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InboxMessageHandler.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InboxMessageHandler.java
@@ -1,0 +1,30 @@
+package com.trustamarket.inspectionservice.inspection.application.service;
+
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+// Kafka 소비 멱등성 오케스트레이션. dedup(SELECT) + 도메인 처리 + inbox 기록(INSERT)을 한 트랜잭션으로 묶는다.
+// 트랜잭션 경계를 application 계층에 두어, 리스너(adapter)는 반환 후 동기 ack만 하면 된다 — 반환 시점엔 이미 커밋됐으므로.
+// 같은 eventId는 같은 파티션(productId key)→같은 스레드로 순차 처리되므로 isAlreadyProcessed에 race가 없다.
+@Service
+@RequiredArgsConstructor
+public class InboxMessageHandler {
+
+    private final InboxRepository inboxRepository;
+
+    // 처음 보는 이벤트면 domainWork 실행 후 inbox 기록하고 true, 이미 처리한 중복이면 domainWork 없이 false.
+    @Transactional
+    public boolean process(UUID eventId, String consumerGroup, InboxPurpose purpose, Runnable domainWork) {
+        if (inboxRepository.isAlreadyProcessed(eventId, consumerGroup)) {
+            return false;
+        }
+        domainWork.run();
+        inboxRepository.record(eventId, consumerGroup, purpose);
+        return true;
+    }
+}

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionService.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionService.java
@@ -61,9 +61,14 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void request(RequestInspectionCommand command) {
+        ProductId productId = ProductId.of(command.productId());
+        // 1 product → 1 inspection 불변식. Inbox(eventId) 우회 시에도 productId 기준 도메인 가드로 중복 생성 차단.
+        if (inspectionRepository.findByProductId(productId).isPresent()) {
+            return;
+        }
         Inspection inspection = Inspection.request(
                 InspectionId.generate(),
-                ProductId.of(command.productId()),
+                productId,
                 SellerId.of(command.sellerId()),
                 CenterId.of(command.centerId()),
                 Money.of(command.originalPriceAmount(), CurrencyCode.valueOf(command.currency())),

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       file: sql/V001__init.sql
       relativeToChangelogFile: true
+  - include:
+      file: sql/V002__create_inbox.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/sql/V002__create_inbox.sql
+++ b/src/main/resources/db/changelog/sql/V002__create_inbox.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset seungwon:4
+CREATE TABLE IF NOT EXISTS p_inspection_inboxes (
+    id             UUID         PRIMARY KEY,
+    event_id       UUID         NOT NULL,
+    consumer_group VARCHAR(50)  NOT NULL,
+    purpose        VARCHAR(30)  NOT NULL,
+    created_at     TIMESTAMPTZ  NOT NULL,
+    CONSTRAINT uq_p_inspection_inboxes_event_id_consumer_group UNIQUE (event_id, consumer_group)
+);

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumerTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,6 +22,8 @@ class CarrierDeliveryCompletedConsumerTest {
 
     @Mock
     private MarkArrivedUseCase markArrivedUseCase;
+    @Mock
+    private Acknowledgment ack;
 
     private CarrierDeliveryCompletedConsumer consumer;
 
@@ -33,24 +35,26 @@ class CarrierDeliveryCompletedConsumerTest {
     }
 
     @Test
-    @DisplayName("유효한 페이로드를 수신하면 productId를 담은 커맨드로 markArrived()를 호출한다")
-    void consume_validPayload_callsMarkArrived() {
+    @DisplayName("유효한 페이로드를 수신하면 markArrived() 호출 후 ack한다")
+    void consume_validPayload_callsMarkArrivedAndAcks() {
         String payload = """
                 {"productId": "a1b2c3d4-0000-0000-0000-000000000001"}
                 """;
 
-        consumer.consume(payload);
+        consumer.consume(payload, ack);
 
         ArgumentCaptor<MarkArrivedCommand> captor = ArgumentCaptor.forClass(MarkArrivedCommand.class);
         then(markArrivedUseCase).should().markArrived(captor.capture());
         assertThat(captor.getValue().productId()).isEqualTo(PRODUCT_ID);
+        then(ack).should().acknowledge();
     }
 
     @Test
-    @DisplayName("JSON 파싱 실패 시 RuntimeException을 던지고 UseCase를 호출하지 않는다")
-    void consume_invalidJson_throwsRuntimeException() {
-        assertThatThrownBy(() -> consumer.consume("invalid json"))
-                .isInstanceOf(RuntimeException.class);
+    @DisplayName("JSON 파싱 실패 시 ack+skip하고 UseCase를 호출하지 않는다 (poison-pill 차단)")
+    void consume_invalidJson_acksAndSkips() {
+        consumer.consume("invalid json", ack);
+
         then(markArrivedUseCase).shouldHaveNoInteractions();
+        then(ack).should().acknowledge();
     }
 }

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumerTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,6 +22,8 @@ class CarrierReturnCompletedConsumerTest {
 
     @Mock
     private CompleteReturnUseCase completeReturnUseCase;
+    @Mock
+    private Acknowledgment ack;
 
     private CarrierReturnCompletedConsumer consumer;
 
@@ -33,24 +35,26 @@ class CarrierReturnCompletedConsumerTest {
     }
 
     @Test
-    @DisplayName("유효한 페이로드를 수신하면 productId를 담은 커맨드로 completeReturn()을 호출한다")
-    void consume_validPayload_callsCompleteReturn() {
+    @DisplayName("유효한 페이로드를 수신하면 completeReturn() 호출 후 ack한다")
+    void consume_validPayload_callsCompleteReturnAndAcks() {
         String payload = """
                 {"productId": "a1b2c3d4-0000-0000-0000-000000000001"}
                 """;
 
-        consumer.consume(payload);
+        consumer.consume(payload, ack);
 
         ArgumentCaptor<CompleteReturnCommand> captor = ArgumentCaptor.forClass(CompleteReturnCommand.class);
         then(completeReturnUseCase).should().completeReturn(captor.capture());
         assertThat(captor.getValue().productId()).isEqualTo(PRODUCT_ID);
+        then(ack).should().acknowledge();
     }
 
     @Test
-    @DisplayName("JSON 파싱 실패 시 RuntimeException을 던지고 UseCase를 호출하지 않는다")
-    void consume_invalidJson_throwsRuntimeException() {
-        assertThatThrownBy(() -> consumer.consume("invalid json"))
-                .isInstanceOf(RuntimeException.class);
+    @DisplayName("JSON 파싱 실패 시 ack+skip하고 UseCase를 호출하지 않는다 (poison-pill 차단)")
+    void consume_invalidJson_acksAndSkips() {
+        consumer.consume("invalid json", ack);
+
         then(completeReturnUseCase).shouldHaveNoInteractions();
+        then(ack).should().acknowledge();
     }
 }

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceAcceptedConsumerTest.java
@@ -1,8 +1,8 @@
 package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trustamarket.inspectionservice.inspection.application.dto.command.RequestInspectionCommand;
-import com.trustamarket.inspectionservice.inspection.application.port.in.RequestInspectionUseCase;
+import com.trustamarket.inspectionservice.inspection.application.dto.command.AcceptPriceCommand;
+import com.trustamarket.inspectionservice.inspection.application.port.in.AcceptPriceUseCase;
 import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
 import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,44 +23,39 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
-class InspectionRequestedConsumerTest {
+class InspectionPriceAcceptedConsumerTest {
 
     @Mock
-    private RequestInspectionUseCase requestInspectionUseCase;
+    private AcceptPriceUseCase acceptPriceUseCase;
     @Mock
     private InboxMessageHandler inboxMessageHandler;
     @Mock
     private Acknowledgment ack;
 
-    private InspectionRequestedConsumer consumer;
+    private InspectionPriceAcceptedConsumer consumer;
 
     private static final String CONSUMER_GROUP = "inspection-service";
-    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-000000000009");
+    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-00000000000a");
     private static final UUID PRODUCT_ID = UUID.fromString("a1b2c3d4-0000-0000-0000-000000000001");
-    private static final UUID SELLER_ID  = UUID.fromString("b2c3d4e5-0000-0000-0000-000000000002");
-    private static final UUID CENTER_ID  = UUID.fromString("c3d4e5f6-0000-0000-0000-000000000003");
 
     private static final String VALID_PAYLOAD = """
             {
-              "eventId": "e0000000-0000-0000-0000-000000000009",
+              "eventId": "e0000000-0000-0000-0000-00000000000a",
               "productId": "a1b2c3d4-0000-0000-0000-000000000001",
               "sellerId": "b2c3d4e5-0000-0000-0000-000000000002",
-              "centerId": "c3d4e5f6-0000-0000-0000-000000000003",
-              "originalPriceAmount": 1500000,
-              "currency": "KRW"
+              "finalPrice": 1400000
             }
             """;
 
     @BeforeEach
     void setUp() {
-        consumer = new InspectionRequestedConsumer(requestInspectionUseCase, inboxMessageHandler, new ObjectMapper());
+        consumer = new InspectionPriceAcceptedConsumer(acceptPriceUseCase, inboxMessageHandler, new ObjectMapper());
     }
 
     @Test
     @DisplayName("유효 페이로드면 eventId·purpose와 함께 핸들러에 위임하고, 도메인 호출 후 ack한다")
     void consume_validPayload_delegatesAndAcks() {
-        // 핸들러가 처음 보는 이벤트로 판단(true)하고 domainWork를 실행하는 상황을 흉내낸다.
-        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.INSPECTION_REQUESTED), any(Runnable.class)))
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.INSPECTION_PRICE_ACCEPTED), any(Runnable.class)))
                 .willAnswer(inv -> {
                     inv.getArgument(3, Runnable.class).run();
                     return true;
@@ -68,11 +63,9 @@ class InspectionRequestedConsumerTest {
 
         consumer.consume(VALID_PAYLOAD, ack);
 
-        ArgumentCaptor<RequestInspectionCommand> captor = ArgumentCaptor.forClass(RequestInspectionCommand.class);
-        then(requestInspectionUseCase).should().request(captor.capture());
+        ArgumentCaptor<AcceptPriceCommand> captor = ArgumentCaptor.forClass(AcceptPriceCommand.class);
+        then(acceptPriceUseCase).should().accept(captor.capture());
         assertThat(captor.getValue().productId()).isEqualTo(PRODUCT_ID);
-        assertThat(captor.getValue().sellerId()).isEqualTo(SELLER_ID);
-        assertThat(captor.getValue().centerId()).isEqualTo(CENTER_ID);
         then(ack).should().acknowledge();
     }
 
@@ -82,7 +75,7 @@ class InspectionRequestedConsumerTest {
         consumer.consume("invalid json", ack);
 
         then(inboxMessageHandler).shouldHaveNoInteractions();
-        then(requestInspectionUseCase).shouldHaveNoInteractions();
+        then(acceptPriceUseCase).shouldHaveNoInteractions();
         then(ack).should().acknowledge();
     }
 }

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/InspectionPriceRejectedConsumerTest.java
@@ -1,8 +1,8 @@
 package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trustamarket.inspectionservice.inspection.application.dto.command.RequestInspectionCommand;
-import com.trustamarket.inspectionservice.inspection.application.port.in.RequestInspectionUseCase;
+import com.trustamarket.inspectionservice.inspection.application.dto.command.RejectPriceCommand;
+import com.trustamarket.inspectionservice.inspection.application.port.in.RejectPriceUseCase;
 import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
 import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,44 +23,39 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
-class InspectionRequestedConsumerTest {
+class InspectionPriceRejectedConsumerTest {
 
     @Mock
-    private RequestInspectionUseCase requestInspectionUseCase;
+    private RejectPriceUseCase rejectPriceUseCase;
     @Mock
     private InboxMessageHandler inboxMessageHandler;
     @Mock
     private Acknowledgment ack;
 
-    private InspectionRequestedConsumer consumer;
+    private InspectionPriceRejectedConsumer consumer;
 
     private static final String CONSUMER_GROUP = "inspection-service";
-    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-000000000009");
+    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-00000000000b");
     private static final UUID PRODUCT_ID = UUID.fromString("a1b2c3d4-0000-0000-0000-000000000001");
-    private static final UUID SELLER_ID  = UUID.fromString("b2c3d4e5-0000-0000-0000-000000000002");
-    private static final UUID CENTER_ID  = UUID.fromString("c3d4e5f6-0000-0000-0000-000000000003");
 
     private static final String VALID_PAYLOAD = """
             {
-              "eventId": "e0000000-0000-0000-0000-000000000009",
+              "eventId": "e0000000-0000-0000-0000-00000000000b",
               "productId": "a1b2c3d4-0000-0000-0000-000000000001",
               "sellerId": "b2c3d4e5-0000-0000-0000-000000000002",
-              "centerId": "c3d4e5f6-0000-0000-0000-000000000003",
-              "originalPriceAmount": 1500000,
-              "currency": "KRW"
+              "reason": "판매자 가격 거절"
             }
             """;
 
     @BeforeEach
     void setUp() {
-        consumer = new InspectionRequestedConsumer(requestInspectionUseCase, inboxMessageHandler, new ObjectMapper());
+        consumer = new InspectionPriceRejectedConsumer(rejectPriceUseCase, inboxMessageHandler, new ObjectMapper());
     }
 
     @Test
     @DisplayName("유효 페이로드면 eventId·purpose와 함께 핸들러에 위임하고, 도메인 호출 후 ack한다")
     void consume_validPayload_delegatesAndAcks() {
-        // 핸들러가 처음 보는 이벤트로 판단(true)하고 domainWork를 실행하는 상황을 흉내낸다.
-        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.INSPECTION_REQUESTED), any(Runnable.class)))
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.INSPECTION_PRICE_REJECTED), any(Runnable.class)))
                 .willAnswer(inv -> {
                     inv.getArgument(3, Runnable.class).run();
                     return true;
@@ -68,11 +63,9 @@ class InspectionRequestedConsumerTest {
 
         consumer.consume(VALID_PAYLOAD, ack);
 
-        ArgumentCaptor<RequestInspectionCommand> captor = ArgumentCaptor.forClass(RequestInspectionCommand.class);
-        then(requestInspectionUseCase).should().request(captor.capture());
+        ArgumentCaptor<RejectPriceCommand> captor = ArgumentCaptor.forClass(RejectPriceCommand.class);
+        then(rejectPriceUseCase).should().reject(captor.capture());
         assertThat(captor.getValue().productId()).isEqualTo(PRODUCT_ID);
-        assertThat(captor.getValue().sellerId()).isEqualTo(SELLER_ID);
-        assertThat(captor.getValue().centerId()).isEqualTo(CENTER_ID);
         then(ack).should().acknowledge();
     }
 
@@ -82,7 +75,7 @@ class InspectionRequestedConsumerTest {
         consumer.consume("invalid json", ack);
 
         then(inboxMessageHandler).shouldHaveNoInteractions();
-        then(requestInspectionUseCase).shouldHaveNoInteractions();
+        then(rejectPriceUseCase).shouldHaveNoInteractions();
         then(ack).should().acknowledge();
     }
 }

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InboxMessageHandlerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InboxMessageHandlerTest.java
@@ -1,0 +1,58 @@
+package com.trustamarket.inspectionservice.inspection.application.service;
+
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class InboxMessageHandlerTest {
+
+    @Mock
+    private InboxRepository inboxRepository;
+
+    @InjectMocks
+    private InboxMessageHandler handler;
+
+    private static final UUID EVENT_ID = UUID.fromString("e0000000-0000-0000-0000-000000000009");
+    private static final String GROUP = "inspection-service";
+
+    @Test
+    @DisplayName("처음 보는 이벤트면 domainWork를 실행하고 inbox에 기록한 뒤 true를 반환한다")
+    void process_firstTime_runsWorkAndRecords() {
+        given(inboxRepository.isAlreadyProcessed(EVENT_ID, GROUP)).willReturn(false);
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        boolean processed = handler.process(EVENT_ID, GROUP, InboxPurpose.INSPECTION_REQUESTED, () -> ran.set(true));
+
+        assertThat(processed).isTrue();
+        assertThat(ran).isTrue();
+        then(inboxRepository).should().record(EVENT_ID, GROUP, InboxPurpose.INSPECTION_REQUESTED);
+    }
+
+    @Test
+    @DisplayName("이미 처리한 이벤트(중복)면 domainWork를 실행하지 않고 기록도 없이 false를 반환한다")
+    void process_duplicate_skipsWork() {
+        given(inboxRepository.isAlreadyProcessed(EVENT_ID, GROUP)).willReturn(true);
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        boolean processed = handler.process(EVENT_ID, GROUP, InboxPurpose.INSPECTION_REQUESTED, () -> ran.set(true));
+
+        assertThat(processed).isFalse();
+        assertThat(ran).isFalse();
+        then(inboxRepository).should(never()).record(any(), any(), any());
+    }
+}

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionServiceTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionServiceTest.java
@@ -135,6 +135,17 @@ class InspectionServiceTest {
             UUID second = captor.getAllValues().get(1).getId().value();
             assertThat(first).isNotEqualTo(second);
         }
+
+        @Test
+        @DisplayName("같은 productId의 검수가 이미 있으면 새로 생성하지 않고 skip한다 (1 product → 1 inspection)")
+        void request_duplicateProductId_skips() {
+            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID)))
+                    .willReturn(Optional.of(requestedInspection()));
+
+            inspectionService.request(validCommand());
+
+            then(inspectionRepository).should(org.mockito.Mockito.never()).save(any(Inspection.class));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 🌱 설명

at-least-once 재배달로 인한 검수 중복 생성 문제를 해결했습니다.

## 📌 관련 이슈

close #63 

## ✅ 주요 변경 사항

- Inbox 멱등성 도입

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 중복 Kafka 메시지 처리 방지로 메시지 처리 신뢰성 향상
  * 동일 상품에 대한 중복 검사 요청 자동 차단

* **버그 수정**
  * 메시지 재처리로 인한 중복 처리 문제 해결

* **개선**
  * 메시지 처리 흐름 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->