### PR TITLE
[fix] at-least-once 재배달로 인한 검수 중복 생성 - Inbox 멱등성 도입

### DIFF
--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumer.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.MarkArrivedCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.MarkArrivedUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,10 +17,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CarrierDeliveryCompletedConsumer {
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+
     private final MarkArrivedUseCase markArrivedUseCase;
+    private final InboxMessageHandler inboxMessageHandler;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "carrier.delivery_completed", groupId = "inspection-service")
+    // dedup+도메인은 InboxMessageHandler가 한 트랜잭션으로 처리. 반환 시점엔 커밋 완료 → 동기 ack 안전(유실 0).
+    @KafkaListener(topics = "carrier.delivery_completed", groupId = CONSUMER_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         CarrierDeliveryCompletedEvent event;
         try {
@@ -30,9 +36,15 @@ public class CarrierDeliveryCompletedConsumer {
             return;
         }
 
-        markArrivedUseCase.markArrived(new MarkArrivedCommand(event.productId()));
-        log.info("상품 도착 확인 완료: productId={}", event.productId());
-        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        boolean processed = inboxMessageHandler.process(
+                event.eventId(), CONSUMER_GROUP, InboxPurpose.CARRIER_DELIVERY_COMPLETED,
+                () -> markArrivedUseCase.markArrived(new MarkArrivedCommand(event.productId())));
+
+        if (processed) {
+            log.info("상품 도착 확인 완료: eventId={}, productId={}", event.eventId(), event.productId());
+        } else {
+            log.info("carrier.delivery_completed 중복 메시지 — skip: eventId={}, productId={}", event.eventId(), event.productId());
+        }
         ack.acknowledge();
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedEvent.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedEvent.java
@@ -3,6 +3,7 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 import java.util.UUID;
 
 record CarrierDeliveryCompletedEvent(
+        UUID eventId,
         UUID productId
 ) {
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumer.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumer.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.CompleteReturnCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.CompleteReturnUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,10 +17,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CarrierReturnCompletedConsumer {
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+
     private final CompleteReturnUseCase completeReturnUseCase;
+    private final InboxMessageHandler inboxMessageHandler;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "carrier.return_completed", groupId = "inspection-service")
+    // dedup+도메인은 InboxMessageHandler가 한 트랜잭션으로 처리. 반환 시점엔 커밋 완료 → 동기 ack 안전(유실 0).
+    @KafkaListener(topics = "carrier.return_completed", groupId = CONSUMER_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         CarrierReturnCompletedEvent event;
         try {
@@ -30,9 +36,15 @@ public class CarrierReturnCompletedConsumer {
             return;
         }
 
-        completeReturnUseCase.completeReturn(new CompleteReturnCommand(event.productId()));
-        log.info("반송 완료 처리: productId={}", event.productId());
-        // 처리 성공 후 오프셋 커밋 — manual ack 모드에서 ack 누락 시 미커밋→재기동 시 토픽 전체 재소비(#61)
+        boolean processed = inboxMessageHandler.process(
+                event.eventId(), CONSUMER_GROUP, InboxPurpose.CARRIER_RETURN_COMPLETED,
+                () -> completeReturnUseCase.completeReturn(new CompleteReturnCommand(event.productId())));
+
+        if (processed) {
+            log.info("반송 완료 처리: eventId={}, productId={}", event.eventId(), event.productId());
+        } else {
+            log.info("carrier.return_completed 중복 메시지 — skip: eventId={}, productId={}", event.eventId(), event.productId());
+        }
         ack.acknowledge();
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedEvent.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedEvent.java
@@ -3,6 +3,7 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 import java.util.UUID;
 
 public record CarrierReturnCompletedEvent(
+        UUID eventId,
         UUID productId
 ) {
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaEntity.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/inbox/InboxJpaEntity.java
@@ -1,6 +1,8 @@
 package com.trustamarket.inspectionservice.inspection.adapter.out.persistence.inbox;
 
 import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionErrorCode;
+import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -49,10 +51,10 @@ public class InboxJpaEntity {
     }
 
     public static InboxJpaEntity forKafkaEvent(UUID eventId, String consumerGroup, InboxPurpose purpose) {
-        Objects.requireNonNull(eventId, "eventId must not be null");
-        Objects.requireNonNull(purpose, "purpose must not be null");
+        Objects.requireNonNull(eventId, "eventId는 null일 수 없습니다");
+        Objects.requireNonNull(purpose, "purpose는 null일 수 없습니다");
         if (consumerGroup == null || consumerGroup.isBlank()) {
-            throw new IllegalArgumentException("consumerGroup must not be blank");
+            throw new InspectionException(InspectionErrorCode.INVALID_CONSUMER_GROUP);
         }
         return new InboxJpaEntity(UUID.randomUUID(), eventId, consumerGroup, purpose, Instant.now());
     }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxPurpose.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InboxPurpose.java
@@ -4,5 +4,7 @@ package com.trustamarket.inspectionservice.inspection.application.port.out;
 public enum InboxPurpose {
     INSPECTION_REQUESTED,
     INSPECTION_PRICE_ACCEPTED,
-    INSPECTION_PRICE_REJECTED
+    INSPECTION_PRICE_REJECTED,
+    CARRIER_DELIVERY_COMPLETED,
+    CARRIER_RETURN_COMPLETED
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/domain/exception/InspectionErrorCode.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/domain/exception/InspectionErrorCode.java
@@ -18,7 +18,8 @@ public enum InspectionErrorCode implements ErrorCodeSpec {
     INVALID_INSPECTION_ID("IN-011", HttpStatus.BAD_REQUEST, "InspectionId는 null일 수 없습니다", ""),
     INVALID_PRODUCT_ID("IN-012", HttpStatus.BAD_REQUEST, "ProductId는 null일 수 없습니다", ""),
     INVALID_MONEY_AMOUNT("IN-013", HttpStatus.BAD_REQUEST, "금액(amount)은 음수일 수 없습니다", "amount"),
-    INSPECTION_ACCESS_DENIED("IN-014", HttpStatus.FORBIDDEN, "본인의 검수 정보만 조회할 수 있습니다", "");
+    INSPECTION_ACCESS_DENIED("IN-014", HttpStatus.FORBIDDEN, "본인의 검수 정보만 조회할 수 있습니다", ""),
+    INVALID_CONSUMER_GROUP("IN-015", HttpStatus.BAD_REQUEST, "consumerGroup은 null이거나 공백일 수 없습니다", "consumerGroup");
 
     private final String code;
     private final HttpStatus status;

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierDeliveryCompletedConsumerTest.java
@@ -3,6 +3,8 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.MarkArrivedCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.MarkArrivedUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,9 @@ import org.springframework.kafka.support.Acknowledgment;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,25 +28,39 @@ class CarrierDeliveryCompletedConsumerTest {
     @Mock
     private MarkArrivedUseCase markArrivedUseCase;
     @Mock
+    private InboxMessageHandler inboxMessageHandler;
+    @Mock
     private Acknowledgment ack;
 
     private CarrierDeliveryCompletedConsumer consumer;
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-000000000009");
     private static final UUID PRODUCT_ID = UUID.fromString("a1b2c3d4-0000-0000-0000-000000000001");
+
+    private static final String VALID_PAYLOAD = """
+            {
+              "eventId": "e0000000-0000-0000-0000-000000000009",
+              "productId": "a1b2c3d4-0000-0000-0000-000000000001"
+            }
+            """;
 
     @BeforeEach
     void setUp() {
-        consumer = new CarrierDeliveryCompletedConsumer(markArrivedUseCase, new ObjectMapper());
+        consumer = new CarrierDeliveryCompletedConsumer(markArrivedUseCase, inboxMessageHandler, new ObjectMapper());
     }
 
     @Test
-    @DisplayName("유효한 페이로드를 수신하면 markArrived() 호출 후 ack한다")
-    void consume_validPayload_callsMarkArrivedAndAcks() {
-        String payload = """
-                {"productId": "a1b2c3d4-0000-0000-0000-000000000001"}
-                """;
+    @DisplayName("유효 페이로드면 eventId·purpose와 함께 핸들러에 위임하고, 도메인 호출 후 ack한다")
+    void consume_validPayload_delegatesAndAcks() {
+        // 핸들러가 처음 보는 이벤트로 판단(true)하고 domainWork를 실행하는 상황을 흉내낸다.
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.CARRIER_DELIVERY_COMPLETED), any(Runnable.class)))
+                .willAnswer(inv -> {
+                    inv.getArgument(3, Runnable.class).run();
+                    return true;
+                });
 
-        consumer.consume(payload, ack);
+        consumer.consume(VALID_PAYLOAD, ack);
 
         ArgumentCaptor<MarkArrivedCommand> captor = ArgumentCaptor.forClass(MarkArrivedCommand.class);
         then(markArrivedUseCase).should().markArrived(captor.capture());
@@ -50,10 +69,23 @@ class CarrierDeliveryCompletedConsumerTest {
     }
 
     @Test
-    @DisplayName("JSON 파싱 실패 시 ack+skip하고 UseCase를 호출하지 않는다 (poison-pill 차단)")
+    @DisplayName("중복 이벤트(핸들러 false)면 도메인을 호출하지 않고 ack만 한다 (at-least-once 재배달 멱등)")
+    void consume_duplicate_skipsDomainButAcks() {
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.CARRIER_DELIVERY_COMPLETED), any(Runnable.class)))
+                .willReturn(false);
+
+        consumer.consume(VALID_PAYLOAD, ack);
+
+        then(markArrivedUseCase).shouldHaveNoInteractions();
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 실패 시 ack+skip하고 핸들러·UseCase를 건드리지 않는다 (poison-pill 차단)")
     void consume_invalidJson_acksAndSkips() {
         consumer.consume("invalid json", ack);
 
+        then(inboxMessageHandler).shouldHaveNoInteractions();
         then(markArrivedUseCase).shouldHaveNoInteractions();
         then(ack).should().acknowledge();
     }

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumerTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/adapter/in/messaging/CarrierReturnCompletedConsumerTest.java
@@ -3,6 +3,8 @@ package com.trustamarket.inspectionservice.inspection.adapter.in.messaging;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trustamarket.inspectionservice.inspection.application.dto.command.CompleteReturnCommand;
 import com.trustamarket.inspectionservice.inspection.application.port.in.CompleteReturnUseCase;
+import com.trustamarket.inspectionservice.inspection.application.port.out.InboxPurpose;
+import com.trustamarket.inspectionservice.inspection.application.service.InboxMessageHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,9 @@ import org.springframework.kafka.support.Acknowledgment;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,25 +28,38 @@ class CarrierReturnCompletedConsumerTest {
     @Mock
     private CompleteReturnUseCase completeReturnUseCase;
     @Mock
+    private InboxMessageHandler inboxMessageHandler;
+    @Mock
     private Acknowledgment ack;
 
     private CarrierReturnCompletedConsumer consumer;
 
+    private static final String CONSUMER_GROUP = "inspection-service";
+    private static final UUID EVENT_ID   = UUID.fromString("e0000000-0000-0000-0000-000000000009");
     private static final UUID PRODUCT_ID = UUID.fromString("a1b2c3d4-0000-0000-0000-000000000001");
+
+    private static final String VALID_PAYLOAD = """
+            {
+              "eventId": "e0000000-0000-0000-0000-000000000009",
+              "productId": "a1b2c3d4-0000-0000-0000-000000000001"
+            }
+            """;
 
     @BeforeEach
     void setUp() {
-        consumer = new CarrierReturnCompletedConsumer(completeReturnUseCase, new ObjectMapper());
+        consumer = new CarrierReturnCompletedConsumer(completeReturnUseCase, inboxMessageHandler, new ObjectMapper());
     }
 
     @Test
-    @DisplayName("유효한 페이로드를 수신하면 completeReturn() 호출 후 ack한다")
-    void consume_validPayload_callsCompleteReturnAndAcks() {
-        String payload = """
-                {"productId": "a1b2c3d4-0000-0000-0000-000000000001"}
-                """;
+    @DisplayName("유효 페이로드면 eventId·purpose와 함께 핸들러에 위임하고, 도메인 호출 후 ack한다")
+    void consume_validPayload_delegatesAndAcks() {
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.CARRIER_RETURN_COMPLETED), any(Runnable.class)))
+                .willAnswer(inv -> {
+                    inv.getArgument(3, Runnable.class).run();
+                    return true;
+                });
 
-        consumer.consume(payload, ack);
+        consumer.consume(VALID_PAYLOAD, ack);
 
         ArgumentCaptor<CompleteReturnCommand> captor = ArgumentCaptor.forClass(CompleteReturnCommand.class);
         then(completeReturnUseCase).should().completeReturn(captor.capture());
@@ -50,10 +68,23 @@ class CarrierReturnCompletedConsumerTest {
     }
 
     @Test
-    @DisplayName("JSON 파싱 실패 시 ack+skip하고 UseCase를 호출하지 않는다 (poison-pill 차단)")
+    @DisplayName("중복 이벤트(핸들러 false)면 도메인을 호출하지 않고 ack만 한다 (at-least-once 재배달 멱등)")
+    void consume_duplicate_skipsDomainButAcks() {
+        given(inboxMessageHandler.process(eq(EVENT_ID), eq(CONSUMER_GROUP), eq(InboxPurpose.CARRIER_RETURN_COMPLETED), any(Runnable.class)))
+                .willReturn(false);
+
+        consumer.consume(VALID_PAYLOAD, ack);
+
+        then(completeReturnUseCase).shouldHaveNoInteractions();
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 실패 시 ack+skip하고 핸들러·UseCase를 건드리지 않는다 (poison-pill 차단)")
     void consume_invalidJson_acksAndSkips() {
         consumer.consume("invalid json", ack);
 
+        then(inboxMessageHandler).shouldHaveNoInteractions();
         then(completeReturnUseCase).shouldHaveNoInteractions();
         then(ack).should().acknowledge();
     }


### PR DESCRIPTION
## 🌱 설명

at-least-once 재배달로 인한 검수 중복 생성 문제를 해결했습니다.

## 📌 관련 이슈

close #63 

## ✅ 주요 변경 사항

-Inbox 멱등성 도입

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배송 완료 및 반품 완료 이벤트 처리 시 중복 메시지 방지 기능 추가
  * 이벤트 처리의 트랜잭션 안정성 개선
  * 무효한 컨슈머 그룹 설정에 대한 오류 처리 강화

* **테스트**
  * 메시지 처리 및 중복 방지 로직에 대한 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->