### PR TITLE
[fix] 검수 목록 조회(/api/v1/inspections/me) 정렬 누락으로 신규 검수건이 1페이지에 노출되지 않는 문제

### DIFF
--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionJpaRepository.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionJpaRepository.java
@@ -21,6 +21,7 @@ public interface InspectionJpaRepository extends JpaRepository<InspectionJpaEnti
                 i.originalPriceAmount, i.originalPriceCurrency, i.status, i.requestedAt)
             FROM InspectionJpaEntity i
             WHERE i.sellerId = :sellerId AND i.deletedAt IS NULL
+            ORDER BY i.requestedAt DESC, i.inspectionId DESC
             """)
     List<InspectionSummaryProjection> findSummariesBySellerId(@Param("sellerId") UUID sellerId, Pageable pageable);
 

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: sql/V003__add_seller_id_index.sql
       relativeToChangelogFile: true
+  - include:
+      file: sql/V004__seller_requested_index.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/sql/V001__init.sql
+++ b/src/main/resources/db/changelog/sql/V001__init.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset seungwon:1
+--changeset Seungwon-Choi:1
 CREATE TABLE IF NOT EXISTS p_inspection_centers (
     center_id     UUID         PRIMARY KEY,
     name          VARCHAR(255) NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS p_inspection_centers (
     CONSTRAINT p_inspection_centers_status_check CHECK (status IN ('OPEN', 'MAINTENANCE', 'CLOSED'))
 );
 
---changeset seungwon:2
+--changeset Seungwon-Choi:2
 CREATE TABLE IF NOT EXISTS p_inspections (
     inspection_id            UUID           PRIMARY KEY,
     product_id               UUID           NOT NULL,
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS p_inspections (
     deleted_by               VARCHAR(255)
 );
 
---changeset seungwon:3
+--changeset Seungwon-Choi:3
 CREATE TABLE IF NOT EXISTS p_inspection_photos (
     photo_id      UUID        PRIMARY KEY,
     inspection_id UUID        NOT NULL,

--- a/src/main/resources/db/changelog/sql/V002__create_inbox.sql
+++ b/src/main/resources/db/changelog/sql/V002__create_inbox.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset seungwon:4
+--changeset Seungwon-Choi:4
 CREATE TABLE IF NOT EXISTS p_inspection_inboxes (
     id             UUID         PRIMARY KEY,
     event_id       UUID         NOT NULL,

--- a/src/main/resources/db/changelog/sql/V003__add_seller_id_index.sql
+++ b/src/main/resources/db/changelog/sql/V003__add_seller_id_index.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset seungwon:5 runInTransaction:false
+--changeset Seungwon-Choi:5 runInTransaction:false
 CREATE INDEX IF NOT EXISTS idx_inspections_seller_active
     ON p_inspections (seller_id)
     WHERE deleted_at IS NULL;

--- a/src/main/resources/db/changelog/sql/V004__seller_requested_index.sql
+++ b/src/main/resources/db/changelog/sql/V004__seller_requested_index.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset seungwon:6 runInTransaction:false
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_inspections_seller_requested
+    ON p_inspections (seller_id, requested_at DESC)
+    WHERE deleted_at IS NULL;
+
+--changeset seungwon:7 runInTransaction:false
+DROP INDEX CONCURRENTLY IF EXISTS idx_inspections_seller_active;

--- a/src/main/resources/db/changelog/sql/V004__seller_requested_index.sql
+++ b/src/main/resources/db/changelog/sql/V004__seller_requested_index.sql
@@ -1,9 +1,9 @@
 --liquibase formatted sql
 
---changeset seungwon:6 runInTransaction:false
+--changeset Seungwon-Choi:6 runInTransaction:false
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_inspections_seller_requested
     ON p_inspections (seller_id, requested_at DESC)
     WHERE deleted_at IS NULL;
 
---changeset seungwon:7 runInTransaction:false
+--changeset Seungwon-Choi:7 runInTransaction:false
 DROP INDEX CONCURRENTLY IF EXISTS idx_inspections_seller_active;


### PR DESCRIPTION
## 🌱 설명

/api/v1/inspections/me 엔드포인트 정렬 조건 누락 문제를 해결했습니다.

## 📌 관련 이슈

close #72 

## ✅ 주요 변경 사항

- 정렬 조건 추가
- 인덱스 수정

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 판매자 검사 목록 조회의 정렬 순서를 명시적으로 최적화하여 응답 속도 개선
  * 데이터베이스 인덱싱을 추가하여 판매자별 검사 조회 성능 향상
  * 기존 인덱스를 최적화된 버전으로 교체하여 쿼리 실행 효율성 증대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->