### PR TITLE
[fix] inspection 상태 전환 명령에서 불필요한 photos 조회 제거

### DIFF
--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionJpaEntity.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionJpaEntity.java
@@ -156,18 +156,6 @@ public class InspectionJpaEntity implements Persistable<UUID> {
         this.resultDetail = resultDetail;
     }
 
-    // 추가된 사진만 INSERT, 제거된 사진만 DELETE — 변경 없는 사진은 그대로 유지
-    public void syncPhotos(List<InspectionPhotoJpaEntity> domainPhotos) {
-        photos.removeIf(existing ->
-                domainPhotos.stream().noneMatch(dp -> dp.getPhotoId().equals(existing.getPhotoId()))
-        );
-        domainPhotos.forEach(dp -> {
-            if (photos.stream().noneMatch(existing -> existing.getPhotoId().equals(dp.getPhotoId()))) {
-                photos.add(dp);
-            }
-        });
-    }
-
     public static InspectionJpaEntity of(
             UUID inspectionId,
             UUID productId,

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionMapper.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionMapper.java
@@ -12,6 +12,8 @@ import com.trustamarket.inspectionservice.inspection.domain.vo.SellerId;
 import com.trustamarket.inspectionservice.inspection.application.dto.result.GetInspectionSummaryResult;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class InspectionMapper {
 
@@ -40,7 +42,7 @@ public class InspectionMapper {
         );
     }
 
-    public InspectionJpaEntity updateJpaEntity(InspectionJpaEntity existing, Inspection inspection) {
+    public InspectionJpaEntity updateStatusFields(InspectionJpaEntity existing, Inspection inspection) {
         existing.update(
                 inspection.getStatus(),
                 inspection.getInspectorId() != null ? inspection.getInspectorId().value() : null,
@@ -54,11 +56,6 @@ public class InspectionMapper {
                 inspection.getSuggestedPrice() != null ? inspection.getSuggestedPrice().currency() : null,
                 inspection.getInspectorNote(),
                 inspection.getResultDetail()
-        );
-        existing.syncPhotos(
-                inspection.getPhotos().stream()
-                        .map(p -> InspectionPhotoJpaEntity.of(p.id().value(), p.type(), p.url(), p.caption(), p.displayOrder()))
-                        .toList()
         );
         return existing;
     }
@@ -86,6 +83,30 @@ public class InspectionMapper {
                 entity.getPhotos().stream()
                         .map(p -> InspectionPhoto.of(PhotoId.of(p.getPhotoId()), p.getType(), p.getUrl(), p.getCaption(), p.getDisplayOrder()))
                         .toList()
+        );
+    }
+
+    public Inspection toDomainWithoutPhotos(InspectionJpaEntity entity) {
+        return Inspection.restore(
+                InspectionId.of(entity.getInspectionId()),
+                ProductId.of(entity.getProductId()),
+                SellerId.of(entity.getSellerId()),
+                CenterId.of(entity.getCenterId()),
+                Money.of(entity.getOriginalPriceAmount(), entity.getOriginalPriceCurrency()),
+                entity.getRequestedAt(),
+                entity.getStatus(),
+                entity.getInspectorId() != null ? InspectorId.of(entity.getInspectorId()) : null,
+                entity.getArrivedAt(),
+                entity.getStartedAt(),
+                entity.getInspectionDoneAt(),
+                entity.getPricedAt(),
+                entity.getReturnCompletedAt(),
+                entity.getGrade(),
+                entity.getSuggestedPriceAmount() != null
+                        ? Money.of(entity.getSuggestedPriceAmount(), entity.getSuggestedPriceCurrency()) : null,
+                entity.getInspectorNote(),
+                entity.getResultDetail(),
+                List.of()
         );
     }
 }

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionRepositoryImpl.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/adapter/out/persistence/jpa/InspectionRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.trustamarket.inspectionservice.inspection.adapter.out.persistence.jp
 
 import com.trustamarket.inspectionservice.inspection.application.dto.result.GetInspectionSummaryResult;
 import com.trustamarket.inspectionservice.inspection.application.port.out.InspectionRepository;
+import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionErrorCode;
+import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionException;
 import com.trustamarket.inspectionservice.inspection.domain.model.Inspection;
 import com.trustamarket.inspectionservice.inspection.domain.vo.InspectionId;
 import com.trustamarket.inspectionservice.inspection.domain.vo.ProductId;
@@ -22,12 +24,15 @@ public class InspectionRepositoryImpl implements InspectionRepository {
 
     @Override
     public Inspection save(Inspection inspection) {
-        Optional<InspectionJpaEntity> existing = jpaRepository.findById(inspection.getId().value());
-        if (existing.isPresent()) {
-            mapper.updateJpaEntity(existing.get(), inspection);
-            return mapper.toDomain(existing.get());
-        }
-        return mapper.toDomain(jpaRepository.save(mapper.toJpaEntity(inspection)));
+        return mapper.toDomainWithoutPhotos(jpaRepository.save(mapper.toJpaEntity(inspection)));
+    }
+
+    @Override
+    public Inspection updateStatus(Inspection inspection) {
+        InspectionJpaEntity entity = jpaRepository.findById(inspection.getId().value())
+                .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND));
+        mapper.updateStatusFields(entity, inspection);
+        return mapper.toDomainWithoutPhotos(entity);
     }
 
     @Override
@@ -38,6 +43,16 @@ public class InspectionRepositoryImpl implements InspectionRepository {
     @Override
     public Optional<Inspection> findByProductId(ProductId productId) {
         return jpaRepository.findByProductIdAndDeletedAtIsNull(productId.value()).map(mapper::toDomain);
+    }
+
+    @Override
+    public Optional<Inspection> findByIdWithoutPhotos(InspectionId id) {
+        return jpaRepository.findByInspectionIdAndDeletedAtIsNull(id.value()).map(mapper::toDomainWithoutPhotos);
+    }
+
+    @Override
+    public Optional<Inspection> findByProductIdWithoutPhotos(ProductId productId) {
+        return jpaRepository.findByProductIdAndDeletedAtIsNull(productId.value()).map(mapper::toDomainWithoutPhotos);
     }
 
     @Override

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InspectionRepository.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/port/out/InspectionRepository.java
@@ -13,9 +13,15 @@ public interface InspectionRepository {
 
     Inspection save(Inspection inspection);
 
+    Inspection updateStatus(Inspection inspection);
+
     Optional<Inspection> findById(InspectionId id);
 
     Optional<Inspection> findByProductId(ProductId productId);
+
+    Optional<Inspection> findByIdWithoutPhotos(InspectionId id);
+
+    Optional<Inspection> findByProductIdWithoutPhotos(ProductId productId);
 
     List<GetInspectionSummaryResult> findSummariesBySellerId(SellerId sellerId, int page, int size);
 

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionService.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionService.java
@@ -80,16 +80,16 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void markArrived(MarkArrivedCommand command) {
-        Inspection inspection = inspectionRepository.findByProductId(ProductId.of(command.productId()))
+        Inspection inspection = inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(command.productId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "productId=" + command.productId()));
         inspection.markArrived(Instant.now());
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
     }
 
     @Override
     @Transactional
     public void complete(CompleteInspectionCommand command) {
-        Inspection inspection = inspectionRepository.findById(InspectionId.of(command.inspectionId()))
+        Inspection inspection = inspectionRepository.findByIdWithoutPhotos(InspectionId.of(command.inspectionId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "inspectionId=" + command.inspectionId()));
         inspection.completeInspection(
                 Grade.valueOf(command.grade()),
@@ -98,7 +98,7 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
                 command.resultDetail() != null ? new InspectionResultDetail(command.resultDetail()) : InspectionResultDetail.empty(),
                 Instant.now()
         );
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
         inspectionEventPublisher.publish(new InspectionCompletedEvent(
                 inspection.getId().value(),
                 inspection.getProductId().value(),
@@ -112,14 +112,14 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void fail(FailInspectionCommand command) {
-        Inspection inspection = inspectionRepository.findById(InspectionId.of(command.inspectionId()))
+        Inspection inspection = inspectionRepository.findByIdWithoutPhotos(InspectionId.of(command.inspectionId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "inspectionId=" + command.inspectionId()));
         inspection.failInspection(
                 command.inspectorNote(),
                 command.resultDetail() != null ? new InspectionResultDetail(command.resultDetail()) : InspectionResultDetail.empty(),
                 Instant.now()
         );
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
         inspectionEventPublisher.publish(new InspectionFailedEvent(
                 inspection.getId().value(),
                 inspection.getProductId().value(),
@@ -131,19 +131,19 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void accept(AcceptPriceCommand command) {
-        Inspection inspection = inspectionRepository.findByProductId(ProductId.of(command.productId()))
+        Inspection inspection = inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(command.productId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "productId=" + command.productId()));
         inspection.acceptPrice(Instant.now());
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
     }
 
     @Override
     @Transactional
     public void reject(RejectPriceCommand command) {
-        Inspection inspection = inspectionRepository.findByProductId(ProductId.of(command.productId()))
+        Inspection inspection = inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(command.productId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "productId=" + command.productId()));
         inspection.rejectPrice(Instant.now());
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
         inspectionEventPublisher.publish(new InspectionFailedEvent(
                 inspection.getId().value(),
                 inspection.getProductId().value(),
@@ -155,10 +155,10 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void start(StartInspectionCommand command) {
-        Inspection inspection = inspectionRepository.findById(InspectionId.of(command.inspectionId()))
+        Inspection inspection = inspectionRepository.findByIdWithoutPhotos(InspectionId.of(command.inspectionId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "inspectionId=" + command.inspectionId()));
         inspection.start(InspectorId.of(command.inspectorId()), Instant.now());
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
         inspectionEventPublisher.publish(new InspectionStartedEvent(
                 inspection.getId().value(),
                 inspection.getProductId().value()
@@ -168,10 +168,10 @@ public class InspectionService implements RequestInspectionUseCase, MarkArrivedU
     @Override
     @Transactional
     public void completeReturn(CompleteReturnCommand command) {
-        Inspection inspection = inspectionRepository.findByProductId(ProductId.of(command.productId()))
+        Inspection inspection = inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(command.productId()))
                 .orElseThrow(() -> new InspectionException(InspectionErrorCode.INSPECTION_NOT_FOUND, "productId=" + command.productId()));
         inspection.completeReturn(Instant.now());
-        inspectionRepository.save(inspection);
+        inspectionRepository.updateStatus(inspection);
         inspectionEventPublisher.publish(new InspectionReturnCompletedEvent(
                 inspection.getId().value(),
                 inspection.getProductId().value(),

--- a/src/main/java/com/trustamarket/inspectionservice/inspection/domain/model/Inspection.java
+++ b/src/main/java/com/trustamarket/inspectionservice/inspection/domain/model/Inspection.java
@@ -4,14 +4,12 @@ import com.trustamarket.inspectionservice.center.domain.vo.CenterId;
 import com.trustamarket.inspectionservice.inspection.domain.enums.Grade;
 import com.trustamarket.inspectionservice.inspection.domain.enums.InspectionStatus;
 
-import com.trustamarket.inspectionservice.inspection.domain.enums.PhotoType;
 import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionErrorCode;
 import com.trustamarket.inspectionservice.inspection.domain.exception.InspectionException;
 import com.trustamarket.inspectionservice.inspection.domain.vo.InspectionId;
 import com.trustamarket.inspectionservice.inspection.domain.vo.InspectionResultDetail;
 import com.trustamarket.inspectionservice.inspection.domain.vo.InspectorId;
 import com.trustamarket.inspectionservice.inspection.domain.vo.Money;
-import com.trustamarket.inspectionservice.inspection.domain.vo.PhotoId;
 import com.trustamarket.inspectionservice.inspection.domain.vo.ProductId;
 import com.trustamarket.inspectionservice.inspection.domain.vo.SellerId;
 import lombok.Getter;
@@ -19,10 +17,8 @@ import lombok.Getter;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 @Getter
 public class Inspection {
@@ -183,41 +179,8 @@ public class Inspection {
         this.status = InspectionStatus.RETURN_COMPLETED;
     }
 
-    public PhotoId addPhoto(PhotoType photoType, String url, String caption, int displayOrder) {
-        ensurePhotoTypeAllowed(photoType);
-        PhotoId photoId = PhotoId.generate();
-        photos.add(new InspectionPhoto(photoId, photoType, url, caption, displayOrder));
-        return photoId;
-    }
-
-    public void removePhoto(PhotoId photoId) {
-        InspectionPhoto target = photos.stream()
-                .filter(p -> p.id().equals(photoId))
-                .findFirst()
-                .orElseThrow(() -> new InspectionException(InspectionErrorCode.PHOTO_NOT_FOUND, photoId.toString()));
-        ensurePhotoTypeAllowed(target.type());
-        photos.remove(target);
-    }
-
     public List<InspectionPhoto> getPhotos() {
         return Collections.unmodifiableList(photos);
-    }
-
-    private void ensurePhotoTypeAllowed(PhotoType photoType) {
-        Set<PhotoType> allowed = allowedPhotoTypes();
-        if (!allowed.contains(photoType)) {
-            throw new InspectionException(
-                    InspectionErrorCode.PHOTO_TYPE_NOT_ALLOWED, "현재: " + status + ", photoType: " + photoType
-            );
-        }
-    }
-
-    private Set<PhotoType> allowedPhotoTypes() {
-        return switch (status) {
-            case REQUESTED, ARRIVED -> EnumSet.of(PhotoType.EXTERIOR, PhotoType.INTERIOR);
-            case IN_PROGRESS -> EnumSet.of(PhotoType.DEFECT, PhotoType.TAG);
-            default -> EnumSet.noneOf(PhotoType.class);
-        };
     }
 
     private void requireStatus(InspectionStatus expected, String action) {

--- a/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionServiceTest.java
+++ b/src/test/java/com/trustamarket/inspectionservice/inspection/application/service/InspectionServiceTest.java
@@ -157,13 +157,13 @@ class InspectionServiceTest {
         @DisplayName("REQUESTED 상태의 검수 요청을 ARRIVED로 전이하고 저장한다")
         void markArrived_success() {
             Inspection inspection = requestedInspection();
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.markArrived(new MarkArrivedCommand(PRODUCT_ID));
 
             ArgumentCaptor<Inspection> captor = ArgumentCaptor.forClass(Inspection.class);
-            then(inspectionRepository).should().save(captor.capture());
+            then(inspectionRepository).should().updateStatus(captor.capture());
             Inspection saved = captor.getValue();
             assertThat(saved.getStatus()).isEqualTo(InspectionStatus.ARRIVED);
             assertThat(saved.getArrivedAt()).isNotNull();
@@ -172,7 +172,7 @@ class InspectionServiceTest {
         @Test
         @DisplayName("productId에 해당하는 검수 요청이 없으면 InspectionException을 던진다")
         void markArrived_notFound_throwsException() {
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.empty());
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inspectionService.markArrived(new MarkArrivedCommand(PRODUCT_ID)))
                     .isInstanceOf(InspectionException.class)
@@ -188,13 +188,13 @@ class InspectionServiceTest {
         @DisplayName("ARRIVED 상태의 검수 요청을 IN_PROGRESS로 전이하고 이벤트를 발행한다")
         void start_success() {
             Inspection inspection = arrivedInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.start(new StartInspectionCommand(inspection.getId().value(), INSPECTOR_ID));
 
             ArgumentCaptor<Inspection> captor = ArgumentCaptor.forClass(Inspection.class);
-            then(inspectionRepository).should().save(captor.capture());
+            then(inspectionRepository).should().updateStatus(captor.capture());
             Inspection saved = captor.getValue();
             assertThat(saved.getStatus()).isEqualTo(InspectionStatus.IN_PROGRESS);
             assertThat(saved.getInspectorId().value()).isEqualTo(INSPECTOR_ID);
@@ -206,7 +206,7 @@ class InspectionServiceTest {
         @DisplayName("inspectionId에 해당하는 검수 요청이 없으면 InspectionException을 던진다")
         void start_notFound_throwsException() {
             UUID unknownId = UUID.randomUUID();
-            given(inspectionRepository.findById(InspectionId.of(unknownId))).willReturn(Optional.empty());
+            given(inspectionRepository.findByIdWithoutPhotos(InspectionId.of(unknownId))).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inspectionService.start(new StartInspectionCommand(unknownId, INSPECTOR_ID)))
                     .isInstanceOf(InspectionException.class)
@@ -217,7 +217,7 @@ class InspectionServiceTest {
         @DisplayName("ARRIVED 상태가 아니면 InspectionException을 던진다")
         void start_wrongStatus_throwsException() {
             Inspection inspection = requestedInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
 
             assertThatThrownBy(() -> inspectionService.start(new StartInspectionCommand(inspection.getId().value(), INSPECTOR_ID)))
                     .isInstanceOf(InspectionException.class);
@@ -236,13 +236,13 @@ class InspectionServiceTest {
         @DisplayName("IN_PROGRESS 상태의 검수를 PRICED로 전이하고 이벤트 1개를 발행한다")
         void complete_success() {
             Inspection inspection = inProgressInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.complete(validCommand(inspection.getId().value()));
 
             ArgumentCaptor<Inspection> captor = ArgumentCaptor.forClass(Inspection.class);
-            then(inspectionRepository).should().save(captor.capture());
+            then(inspectionRepository).should().updateStatus(captor.capture());
             Inspection saved = captor.getValue();
             assertThat(saved.getStatus()).isEqualTo(InspectionStatus.PRICED);
             assertThat(saved.getGrade()).isEqualTo(Grade.A);
@@ -257,8 +257,8 @@ class InspectionServiceTest {
         @DisplayName("InspectionCompletedEvent에 grade, suggestedPriceAmount, currency, inspectorId가 포함된다")
         void complete_event_containsPriceInfo() {
             Inspection inspection = inProgressInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.complete(validCommand(inspection.getId().value()));
 
@@ -275,7 +275,7 @@ class InspectionServiceTest {
         @DisplayName("inspectionId에 해당하는 검수 요청이 없으면 InspectionException을 던진다")
         void complete_notFound_throwsException() {
             UUID unknownId = UUID.randomUUID();
-            given(inspectionRepository.findById(InspectionId.of(unknownId))).willReturn(Optional.empty());
+            given(inspectionRepository.findByIdWithoutPhotos(InspectionId.of(unknownId))).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inspectionService.complete(validCommand(unknownId)))
                     .isInstanceOf(InspectionException.class)
@@ -286,7 +286,7 @@ class InspectionServiceTest {
         @DisplayName("IN_PROGRESS 상태가 아니면 InspectionException을 던진다")
         void complete_wrongStatus_throwsException() {
             Inspection inspection = arrivedInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
 
             assertThatThrownBy(() -> inspectionService.complete(validCommand(inspection.getId().value())))
                     .isInstanceOf(InspectionException.class);
@@ -301,13 +301,13 @@ class InspectionServiceTest {
         @DisplayName("IN_PROGRESS 상태의 검수를 FAILED로 전이하고 저장한다")
         void fail_success() {
             Inspection inspection = inProgressInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.fail(new FailInspectionCommand(inspection.getId().value(), "심각한 손상 발견", null));
 
             ArgumentCaptor<Inspection> captor = ArgumentCaptor.forClass(Inspection.class);
-            then(inspectionRepository).should().save(captor.capture());
+            then(inspectionRepository).should().updateStatus(captor.capture());
             Inspection saved = captor.getValue();
             assertThat(saved.getStatus()).isEqualTo(InspectionStatus.FAILED);
             assertThat(saved.getInspectorNote()).isEqualTo("심각한 손상 발견");
@@ -319,7 +319,7 @@ class InspectionServiceTest {
         @DisplayName("inspectionId에 해당하는 검수 요청이 없으면 InspectionException을 던진다")
         void fail_notFound_throwsException() {
             UUID unknownId = UUID.randomUUID();
-            given(inspectionRepository.findById(InspectionId.of(unknownId))).willReturn(Optional.empty());
+            given(inspectionRepository.findByIdWithoutPhotos(InspectionId.of(unknownId))).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inspectionService.fail(new FailInspectionCommand(unknownId, "손상", null)))
                     .isInstanceOf(InspectionException.class)
@@ -330,7 +330,7 @@ class InspectionServiceTest {
         @DisplayName("IN_PROGRESS 상태가 아니면 InspectionException을 던진다")
         void fail_wrongStatus_throwsException() {
             Inspection inspection = arrivedInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
 
             assertThatThrownBy(() -> inspectionService.fail(new FailInspectionCommand(inspection.getId().value(), "손상", null)))
                     .isInstanceOf(InspectionException.class);
@@ -340,7 +340,7 @@ class InspectionServiceTest {
         @DisplayName("inspectorNote가 blank이면 InspectionException을 던진다")
         void fail_blankNote_throwsException() {
             Inspection inspection = inProgressInspection();
-            given(inspectionRepository.findById(inspection.getId())).willReturn(Optional.of(inspection));
+            given(inspectionRepository.findByIdWithoutPhotos(inspection.getId())).willReturn(Optional.of(inspection));
 
             assertThatThrownBy(() -> inspectionService.fail(new FailInspectionCommand(inspection.getId().value(), "  ", null)))
                     .isInstanceOf(InspectionException.class);
@@ -355,13 +355,13 @@ class InspectionServiceTest {
         @DisplayName("FAILED 상태의 검수를 RETURN_COMPLETED로 전이하고 이벤트를 발행한다")
         void completeReturn_success() {
             Inspection inspection = failedInspection();
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.completeReturn(new CompleteReturnCommand(PRODUCT_ID));
 
             ArgumentCaptor<Inspection> captor = ArgumentCaptor.forClass(Inspection.class);
-            then(inspectionRepository).should().save(captor.capture());
+            then(inspectionRepository).should().updateStatus(captor.capture());
             Inspection saved = captor.getValue();
             assertThat(saved.getStatus()).isEqualTo(InspectionStatus.RETURN_COMPLETED);
             assertThat(saved.getReturnCompletedAt()).isNotNull();
@@ -372,8 +372,8 @@ class InspectionServiceTest {
         @DisplayName("InspectionReturnCompletedEvent에 inspectionId, productId, sellerId가 포함된다")
         void completeReturn_event_containsIds() {
             Inspection inspection = failedInspection();
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
-            given(inspectionRepository.save(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
+            given(inspectionRepository.updateStatus(any(Inspection.class))).willAnswer(inv -> inv.getArgument(0));
 
             inspectionService.completeReturn(new CompleteReturnCommand(PRODUCT_ID));
 
@@ -388,7 +388,7 @@ class InspectionServiceTest {
         @Test
         @DisplayName("productId에 해당하는 검수 요청이 없으면 InspectionException을 던진다")
         void completeReturn_notFound_throwsException() {
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.empty());
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> inspectionService.completeReturn(new CompleteReturnCommand(PRODUCT_ID)))
                     .isInstanceOf(InspectionException.class)
@@ -399,7 +399,7 @@ class InspectionServiceTest {
         @DisplayName("FAILED 상태가 아니면 InspectionException을 던진다")
         void completeReturn_wrongStatus_throwsException() {
             Inspection inspection = inProgressInspection();
-            given(inspectionRepository.findByProductId(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
+            given(inspectionRepository.findByProductIdWithoutPhotos(ProductId.of(PRODUCT_ID))).willReturn(Optional.of(inspection));
 
             assertThatThrownBy(() -> inspectionService.completeReturn(new CompleteReturnCommand(PRODUCT_ID)))
                     .isInstanceOf(InspectionException.class);


### PR DESCRIPTION
## 🌱 설명

inspection 도메인 메서드 재구성을 진행했습니다.

## 📌 관련 이슈

close #74 

## ✅ 주요 변경 사항

- 도메인 메서드 재구성

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 검사 상태 업데이트 처리 로직이 개선되었습니다.

* **Refactor**
  * 검사 데이터 조회 방식이 최적화되었습니다.
  * 검사 및 사진 데이터 동기화 처리 방식이 개선되었습니다.
  * 내부 저장소 인터페이스가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->